### PR TITLE
fix a sed command error

### DIFF
--- a/playbooks/deploy_playbook_aws
+++ b/playbooks/deploy_playbook_aws
@@ -55,7 +55,7 @@ pip install -t lambda -r requirements.txt
 pip install -t lambda  .
 
 aws eks update-kubeconfig --name "${eks_cluster}" --kubeconfig lambda/kubeconfig
-sed -i "s/command: aws-iam-authenticator/command: .\/aws-iam-authenticator/g" lambda/kubeconfig
+sed -i -e "s/command: aws-iam-authenticator/command: .\/aws-iam-authenticator/g" lambda/kubeconfig
 
 cp extra/aws-iam-authenticator lambda/
 


### PR DESCRIPTION
`deploy_playbook_aws` didn't work correctly on my environment because of a sed error.
```bash
$ sed -i "s/command: aws-iam-authenticator/command: .\/aws-iam-authenticator/g" lambda/kubeconfig
sed: 1: "lambda/kubeconfig": extra characters at the end of l command

$ sed -i -e "s/command: aws-iam-authenticator/command: .\/aws-iam-authenticator/g" lambda/kubeconfig
# no error
```